### PR TITLE
Update the general contact address to odm-info@phes-odm.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The ODM is comprised of 15 report tables and six look-up tables, linked to each 
 
 See [contributing](CONTRIBUTING.md) and [Code of conduct](CODE_OF_CONDUCT.md) for more information.
 
-- Issues, suggestions and pull requests are welcomed. use [GH issues](https://github.com/PHES-ODM/PHES-ODM/issues), the [ODM Discourse channel](https://odm.discourse.group) or email [phesd_odm@ohri.ca](mailto:phesd_odm@ohri.ca).
+- Issues, suggestions and pull requests are welcomed. use [GH issues](https://github.com/PHES-ODM/PHES-ODM/issues), the [ODM Discourse channel](https://odm.discourse.group) or email [odm-info@phes-odm.org](mailto:odm-info@phes-odm.org).
 - Follow the [`dev`](https://github.com/PHES-ODM/PHES-ODM/tree/dev) branch for upcoming changes. Also follow version changes in [issues](https://github.com/PHES-ODM/PHES-ODM/issues), [discussions](https://github.com/PHES-ODM/PHES-ODM/discussions), and [projects](https://github.com/PHES-ODM/PHES-ODM/projects).
 - [An international steering committee](https://github.com/PHES-ODM/PHES-ODM/wiki/Steering-Group-Members) guides the development of the data model.
 - Working groups consist of a regular weekly meeting with ODM developers and users. Add hoc working groups are created to develop specific sections of the ODM. An example of the working group the development of quality assurance and control measures.

--- a/roadmap.md
+++ b/roadmap.md
@@ -22,5 +22,5 @@ Documentation that including tutorials, how-to guides, technical references and 
 ## Process
 
 - the PHES-ODM Steering Committee and Working Groups ensures PHES-ODM meets the needs from the full spectrum of users from testing laboratory to public health policy.
-- A working group that meets weekly to discuss ongoing development and receive input from dictionary users. Please email: phesd_odm@ohri.ca if you would like to join the meeting.
+- A working group that meets weekly to discuss ongoing development and receive input from dictionary users. Please email: odm-info@phes-odm.org if you would like to join the meeting.
 - [Code of conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
The general project inbox has moved to `odm-info@phes-odm.org`; the former OHRI address is retired and no longer receives mail. This replaces every remaining reference in this repository's prose files.

Dictionary content (part descriptions in the CSVs) is deliberately not touched here -- that is a versioned dictionary edit and is tracked separately.
